### PR TITLE
Fix/fetch username

### DIFF
--- a/src/main/kotlin/scheduler/ScheduleMessage.kt
+++ b/src/main/kotlin/scheduler/ScheduleMessage.kt
@@ -24,7 +24,12 @@ class ScheduleMessage {
                     .text(text)
                     .postAt(timeToPost)
             }
-            logger.info("The bot is posting this message: {}", postMessage.message.text)
+            if (postMessage.message != null) {
+                logger.info("The bot is posting this message: {}", postMessage.message.text)
+            } else {
+                logger.error("Scheduled message is null. Full response: {}", postMessage)
+            }
+
         } catch (e: IOException) {
             logger.error("error: {}", e.message, e)
         } catch (e: SlackApiException) {

--- a/src/main/kotlin/service/ChannelHistory.kt
+++ b/src/main/kotlin/service/ChannelHistory.kt
@@ -78,6 +78,12 @@ class ChannelHistory {
 
     private fun fetchUsername(userId: String): String {
         val userInfo = slackConnectionInfo.client.methods(slackConnectionInfo.token).usersInfo { r -> r.user(userId) }
-        return userInfo.user.realName
+        val realName = userInfo.user.profile.realName ?: "Unknown User"
+        if (realName == "Unknown User") {
+            logger.error("Error response: {}", userInfo)
+        } else {
+            logger.info("Names fetched 200 OK")
+        }
+        return realName
     }
 }


### PR DESCRIPTION
It seems to exist an issue where if a person in Slack is set to deactivated and is reactivated (in our case in a different department, unknown if this plays a role in the issue)
the first "realName" value of the User object will be null. But further down in the response the user.profile object also has a "realName" value where it was correctly displaying the name