### PR TITLE
Added environment variables

### DIFF
--- a/src/main/kotlin/config/DateTimeToUnixConverter.kt
+++ b/src/main/kotlin/config/DateTimeToUnixConverter.kt
@@ -6,19 +6,34 @@ import org.slf4j.LoggerFactory
 class DateTimeToUnixConverter {
 
     private val logger = LoggerFactory.getLogger("my-awesome-slack-app")
-    private val timeZone = TimeZone.of("Europe/Oslo")
+    private val timeZone = TimeZone.of(System.getenv("TIMEZONE") ?: "Europe/Oslo")
     private val today = Clock.System.todayIn(timeZone)
 
+    companion object {
+        private const val DEFAULT_POSTING_TIME = "14:35"
+        private const val DEFAULT_START_READING_TIME = "7:0"
+        private const val DEFAULT_END_READING_TIME = "14:30"
+
+    }
+
     fun unixTimeStampForPostingMessages(): Instant {
-        val startPosting = today.atTime(14, 35).toInstant(timeZone)
+        val postingTime = System.getenv("POSTING_TIME") ?: DEFAULT_POSTING_TIME
+        val (hour, minute) = postingTime.split(":").map { it.toInt() }
+        val startPosting = today.atTime(hour, minute).toInstant(timeZone)
         logger.info("Today's start posting date is: $startPosting")
         return startPosting
     }
 
     fun unixTimeStampForReadingMessages(): Pair<Instant, Instant> {
-        val startReading = today.atTime(7, 0).toInstant(timeZone)
+        val startReadingTime = System.getenv("START_READING") ?: DEFAULT_START_READING_TIME
+        val endReadingTime = System.getenv("END_READING") ?: DEFAULT_END_READING_TIME
+
+        val (startHour, startMinute) = startReadingTime.split(":").map { it.toInt() }
+        val (endHour, endMinute) = endReadingTime.split(":").map { it.toInt() }
+
+        val startReading = today.atTime(startHour, startMinute).toInstant(timeZone)
         logger.info("Today's start date is: $startReading")
-        val endReading = today.atTime(14, 30).toInstant(timeZone)
+        val endReading = today.atTime(endHour, endMinute).toInstant(timeZone)
         logger.info("Today's end date is: $endReading")
 
         return Pair(startReading, endReading)

--- a/src/main/kotlin/scheduler/ScheduleJob.kt
+++ b/src/main/kotlin/scheduler/ScheduleJob.kt
@@ -7,14 +7,20 @@ import org.quartz.impl.StdSchedulerFactory
 import org.vikl5.service.MessageJob
 
 class ScheduleJob {
+    companion object {
+        private const val DEFAULT_CRON_SCHEDULE = "0 31 14 ? * MON-FRI"
+    }
 
     fun builder() {
         val job = JobBuilder.newJob(MessageJob::class.java)
             .withIdentity("postSlackMessage", "grp1")
             .build()
+
+        val cronSchedule = System.getenv("CRON_SCHEDULE") ?: DEFAULT_CRON_SCHEDULE
+
         val trigger = TriggerBuilder.newTrigger()
             .withIdentity("dailyTrigger", "grp1")
-            .withSchedule(CronScheduleBuilder.cronSchedule("0 31 14 ? * MON-FRI"))
+            .withSchedule(CronScheduleBuilder.cronSchedule(cronSchedule))
             .build()
         val scheduler = StdSchedulerFactory.getDefaultScheduler()
         scheduler.start()


### PR DESCRIPTION
The goal of this PR is to allow users who are running the application as a docker image to add their own scheduling with environment variables to the container. If the scheduling env variables are not added to docker run it will use the default constants defined in the code.